### PR TITLE
Ka-50 export fixes

### DIFF
--- a/TODO-list.txt
+++ b/TODO-list.txt
@@ -11,9 +11,6 @@ Export problems
 - defined class types are not containing all of them
 	- some modules have other types too. Is the class types definition needed per module?
 
-- some long values are having leftovers at the end of the fractional part
-	- try rounding the value to 15 decimal places and shortening when trailing zeroes are not needed
-
 - some LEV elements have value for step in gain instead of arg_value
 	- maybe when arg_value = 0 than look for the step value in gain
 
@@ -25,3 +22,7 @@ M-2000C:
 AV8B:
 
 - Nozzle Control Lever should have step of 0.1, not 0 (arg_value vs. gain problem)
+
+P-51
+
+- Does not have devices defined on elements (maybe only some?)

--- a/src/DcsExportLib/src/DcsExport.cs
+++ b/src/DcsExportLib/src/DcsExport.cs
@@ -50,6 +50,7 @@ namespace DcsExportLib
             services.AddTransient<ILoaderFactory, LoaderFactory>();
             services.AddTransient<IDcsModuleInfoBuilder, DcsModuleInfoBuilder>();
             services.AddTransient<IDevicesLoader, DevicesLoader>();
+            services.AddTransient<IExecutorFactory, ExecutorFactory>();
             
             _serviceProvider = services.BuildServiceProvider();
         }

--- a/src/DcsExportLib/src/Enums/DcsVariables.cs
+++ b/src/DcsExportLib/src/Enums/DcsVariables.cs
@@ -1,0 +1,9 @@
+﻿namespace DcsExportLib.Enums
+{
+    internal class DcsVariables
+    {
+        public const string Elements = "elements";
+        public const string Devices = "devices";
+        public const string LockOnOptions = "LockOn_Options";
+    }
+}

--- a/src/DcsExportLib/src/Executors/CommonExecutor.cs
+++ b/src/DcsExportLib/src/Executors/CommonExecutor.cs
@@ -1,0 +1,30 @@
+﻿using DcsExportLib.DcsObjects;
+using DcsExportLib.Enums;
+using DcsExportLib.Models;
+
+using NLua;
+
+using System.Text;
+
+namespace DcsExportLib.Executors
+{
+    internal class CommonExecutor : IExecutor
+    {
+        public LuaTable ExecuteClickables(Lua lua, DcsModuleInfo moduleInfo)
+        {
+            lua.State.Encoding = Encoding.UTF8;
+
+            LockOnOptions options = new LockOnOptions(moduleInfo.ScriptFolder);
+            lua[DcsVariables.LockOnOptions] = options;
+            lua.DoString("package.path = package.path .. ';Scripts/?.lua'");
+
+            lua.DoFile(ProgramPaths.ExportFunctionsFilePath);
+            
+            var loadRes = lua.LoadFile(moduleInfo.ClickableElementsFolderPath);
+            loadRes.Call();
+
+            // TODO replace with own exception telling consumer that module loading went wrong
+            return lua[DcsVariables.Elements] as LuaTable ?? throw new InvalidOperationException("Cannot load table of elements!");
+        }
+    }
+}

--- a/src/DcsExportLib/src/Executors/IExecutor.cs
+++ b/src/DcsExportLib/src/Executors/IExecutor.cs
@@ -1,0 +1,9 @@
+﻿using DcsExportLib.Models;
+using NLua;
+
+namespace DcsExportLib.Executors;
+
+public interface IExecutor
+{
+    LuaTable ExecuteClickables(Lua lua, DcsModuleInfo moduleInfo);
+}

--- a/src/DcsExportLib/src/Executors/Ka50Executor.cs
+++ b/src/DcsExportLib/src/Executors/Ka50Executor.cs
@@ -1,0 +1,40 @@
+﻿using System.Text;
+using DcsExportLib.DcsObjects;
+using DcsExportLib.Enums;
+using DcsExportLib.Models;
+
+using NLua;
+
+namespace DcsExportLib.Executors
+{
+    public class Ka50Executor : IExecutor
+    {
+        public LuaTable ExecuteClickables(Lua lua, DcsModuleInfo moduleInfo)
+        {
+            lua.State.Encoding = Encoding.UTF8;
+
+            LockOnOptions options = new LockOnOptions(moduleInfo.ScriptFolder);
+            lua[DcsVariables.LockOnOptions] = options;
+            lua.DoString("package.path = package.path .. ';Scripts/?.lua'");
+
+            lua.DoFile(ProgramPaths.ExportFunctionsFilePath);
+            
+            string localizeFunctionStr =
+                @"function LOCALIZE(str)
+                        return str
+                    end";
+
+            string content = File.ReadAllText(moduleInfo.ClickableElementsFolderPath).Replace(@"\%", "%", StringComparison.InvariantCulture);
+            content = content.Replace("dofile(LockOn_Options.script_path..\"Hint_localizer.lua\")", string.Empty);
+            content = localizeFunctionStr + "\r\n\r\n" + content;
+            lua.DoString(content);
+
+            if (lua[DcsVariables.Elements] is not LuaTable elementsTable)
+            {
+                lua.NewTable(DcsVariables.Elements);
+            }
+                
+            return lua[DcsVariables.Elements] as LuaTable ?? throw new InvalidOperationException("Cannot load table of elements!");
+        }
+    }
+}

--- a/src/DcsExportLib/src/Extensions/DecimalExtensions.cs
+++ b/src/DcsExportLib/src/Extensions/DecimalExtensions.cs
@@ -1,0 +1,28 @@
+﻿using System.Globalization;
+
+namespace DcsExportLib.Extensions
+{
+    internal static class DecimalExtensions
+    {
+        /// <summary>
+        /// Rounds the number to given number of decimal places and removes the trailing zeroes
+        /// </summary>
+        /// <param name="value">Value to round and trim</param>
+        /// <param name="decimalPlacesCount">Number of decimal places</param>
+        /// <returns>Rounded and trimmed decimal value</returns>
+        /// <exception cref="ArgumentException">Exception of wrong number of decimal places. Must be > 1</exception>
+        public static decimal Trail(this decimal value, int decimalPlacesCount)
+        {
+            if (decimalPlacesCount <= 0)
+                throw new ArgumentException("Unexpected number of decimal places for trailing.");
+
+            string formatString = "0.";
+
+            for (int i = 0; i < decimalPlacesCount; i++)
+                formatString += "#";
+
+            string strValue = value.ToString(formatString, CultureInfo.InvariantCulture);
+            return Decimal.Parse(strValue);
+        }
+    }
+}

--- a/src/DcsExportLib/src/Factories/ExecutorFactory.cs
+++ b/src/DcsExportLib/src/Factories/ExecutorFactory.cs
@@ -1,0 +1,17 @@
+﻿using DcsExportLib.Executors;
+using DcsExportLib.Models;
+
+namespace DcsExportLib.Factories
+{
+    internal class ExecutorFactory : IExecutorFactory
+    {
+        public IExecutor GetExecutor(DcsModuleInfo moduleInfo)
+        {
+            return moduleInfo.Name switch
+            {
+                "Ka-50 Black Shark" => new Ka50Executor(),
+                _ => new CommonExecutor()
+            };
+        }
+    }
+}

--- a/src/DcsExportLib/src/Factories/IExecutorFactory.cs
+++ b/src/DcsExportLib/src/Factories/IExecutorFactory.cs
@@ -1,0 +1,9 @@
+﻿using DcsExportLib.Executors;
+using DcsExportLib.Models;
+
+namespace DcsExportLib.Factories;
+
+internal interface IExecutorFactory
+{
+    IExecutor GetExecutor(DcsModuleInfo moduleInfo);
+}

--- a/src/DcsExporterApp/src/FileExports/CsvFileExport.cs
+++ b/src/DcsExporterApp/src/FileExports/CsvFileExport.cs
@@ -17,8 +17,9 @@ namespace DCSExporterApp.FileExports
             if(!dirInfo.Exists)
                 dirInfo.Create();
 
-            string fullPath = Path.Combine(directoryPath, $"{module.Info.Name}.{FileExtension}");
+            string fullPath = Path.Combine(directoryPath, $"{module.Info.ModuleDirectoryName}.{FileExtension}");
 
+            // TODO remove invalid characters from path
             using (var writer = new StreamWriter(fullPath))
             using (var csv = new CsvWriter(writer, CultureInfo.InvariantCulture))
             {


### PR DESCRIPTION
- Fixed export for Ka-50
- Decimal number rounding for steps values and limits to 15 dec. places
- Added common exporter for clickable data
- Added exporter of clickable data for Ka-50 (needs special setup to run lua script)
- CSV files are now having same name as module directory to avoid file naming problems
- Added class with names of DCS script variables